### PR TITLE
Miscellaneous type errors

### DIFF
--- a/ao/lists.ao
+++ b/ao/lists.ao
@@ -260,14 +260,14 @@
 @doc.nub.l "remove duplicate values from list"
 @nub.l [step.nub.l] fixpoint apply
 @step.nub.l swap [action.nub.l] [nip inR] if
-@action.nub.l x copy remove.l swap inline put cons.l
+@action.nub.l x copy remove.l swap apply put cons.l
 @test.nub.l "hello, world!" nub.l "helo, wrd!" assertTextEQ1
 @eqv.idempotent.nubList [nub.l] [nub.l nub.l]
 
 @doc.nubBy.l "a`L [eq(a a -- Bool)] -- a`L; value a, provide eq function"
 @nubBy.l [step.nubBy.l] bind fixpoint apply
 @step.nubBy.l rot [action.nubBy.l] [nip2 inR] if
-@action.nubBy.l x copy rot bind partitionBy.l drop swap inline put cons.l
+@action.nubBy.l x copy rot bind partitionBy.l drop swap apply put cons.l
 @test.nubBy.l "hello, world!" [eqb] nubBy.l "helo, wrd!" assertTextEQ1
 
 @doc.sortBy.l "a`L [lt(a a -- Bool)]; sort list of values given a less-than function (a a -- Bool)"

--- a/ao/ord.ao
+++ b/ao/ord.ao
@@ -41,7 +41,7 @@
 @compareUnits %c .inL
 @compareProds 
  .rw .rw dx x swapd pw dpw .wl .apply
- [drop .wl .apply] [inR .wl drop] if
+ [drop .wl .apply] [inR .wl drop dropd] if
 @compareSums .rw .rw [?l.compareSums] [?r.compareSums] if
 @?l.compareSums .rw [.wl ll.compareSums] [.wl rl.compareSums] if
 @?r.compareSums .rw [.wl lr.compareSums] [.wl rr.compareSums] if

--- a/ao/ord.ao
+++ b/ao/ord.ao
@@ -83,7 +83,7 @@
 @-ab.compareStreams drop2 discard2 intro1 inL
 
 @doc.compareTexts "text text -- Ord; compare texts lexicographycally by codepoint order"
-@compareTexts [rawCompareNumbers'] compareLists toOrd
+@compareTexts [rawCompareNumbers] compareLists toOrd
 
 @doc.mkCompareLists "[(a*a)→Ord] -- [(a`L * a`L)→Ord]"
 @doc.mkCompareStreams "[(a*a)→Ord] -- [(a`S * a`S)→Ord]"


### PR DESCRIPTION
This fixes a few type errors. One was an issue with polymorphic recursion, but the other two represent actual bugs. There are 36 words with detected type errors remaining (excluding those that transitively include a TODO, which shouldn't be expected to typecheck). I have taken a look at a few of them, and they all looked like polymorphic recursion issues or actual bugs in the words instead of typechecker issues. It's pretty hard to debug AO code written by other people with the amount of practice I have, so I'm going to just leave the list of failing words here for now and move on.
- assertBalanced.AATree
- assertBalanced.rbt
- bench.docmanip1
- bench.docmanip2
- blackHeight.AATree
- fmap.AATree
- h.assertBalanced.rbt
- insert.m
- insertK.m
- insertKV.t23
- insertK_.m
- insert_.m
- n.assertBalanced.AATree
- n.size.AATree
- n.stdgen.r
- nonEmpty.sortByKey.l
- r.assertBalanced.AATree
- r.size.AATree
- remove.m
- removeKV.bst
- remove_.m
- size.AATree
- size.bst
- size.m
- size.rbt
- sortBy.l
- sortByKey.l
- stdgen.r
- step.sortByKey.l
- test.fromStateSplitNext.r#next
- test.nubAndSort.l#pangram
- test.sortBy.l
- test.sortByKey.l
- testing.t23
- textToTestTree.t23
- wordGenToBoolGen.r

Obviously some of these include others, and e.g. sortBy.l and sortByKey.l probably have essentially the same bug, so these aren't 36 distinct bugs that need to be fixed.
